### PR TITLE
add some build deps to sort (mostly) BSD install problems

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -10,9 +10,13 @@ WriteMakefile(
     ($ExtUtils::MakeMaker::VERSION >= 6.3002
       ? ('LICENSE'=> 'perl')
       : ()),
-    PL_FILES            => {},
+    BUILD_REQUIRES => {
+        'Test::More'  => 0,
+        'Class::Load' => 0,
+        'Path::Tiny'  => 0,
+        'DateTime::Format::SQLite' => 0,
+    },
     PREREQ_PM => {
-        'Test::More'  => 0, # For future tests?
         'Dancer2::Plugin::DBIC' => 0,
         'Dancer2::Plugin::Auth::Extensible' => 0.500,
         'DBIx::Class::ResultClass::HashRefInflator' => 0,


### PR DESCRIPTION
- Test::More moved from PREREQ_PM to BUILD_REQUIRES
- Class::Load and Path::Tiny are used in test script
- DateTime::Format::SQLite solves (mostly BSD) test problems with v0.500
